### PR TITLE
fix in symbol processing

### DIFF
--- a/src/assembler.py
+++ b/src/assembler.py
@@ -296,6 +296,7 @@ def evaluate(expr, symbols, address):
         else:
             if(expr[-1][1] in symbols.defs):
                 result += sign*int(symbols.defs[expr[-1][1]], base=16)
+                expr = expr[:-pop]
             elif(expr[-1][1] in symbols.labelDefs):
                 result += sign*int(symbols.labelDefs[expr[-1][1]], base=16)
                 expr = expr[:-pop]


### PR DESCRIPTION
The expr consumption was missing, and so if you used a label in code like this:

```
       FOO EQ 0x237a
       STA FOO
```

it would get stuck in an infinite loop
